### PR TITLE
Restore prettier to version 2.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
             },
             "devDependencies": {
                 "eslint": "^8.32.0",
-                "prettier": "2.8.1"
+                "prettier": "^2.8.3"
             }
         },
         "node_modules/@derhuerst/http-basic": {
@@ -2211,9 +2211,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-            "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+            "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -4510,9 +4510,9 @@
             "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
         },
         "prettier": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-            "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+            "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
             "dev": true
         },
         "progress": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     },
     "devDependencies": {
         "eslint": "^8.32.0",
-        "prettier": "2.8.1"
+        "prettier": "^2.8.3"
     }
 }


### PR DESCRIPTION
### Checklist
- [X] The pull request has a descriptive title.
- [X] All code changed has been thoroughly tested.
- [X] All code changed has been formatted with prettier using `npm run format`.

---

### Description
- Bump prettier from version 2.8.1 to version 2.8.3

---

### Documentation
- [X] None of the [documentation](https://github.com/NerdyTechy/Melody/wiki) or information in the [README](https://github.com/NerdyTechy/Melody/blob/master/README.md) is incorrect following these changes.

**If any documentation is incorrect as a result of these changes:**
- If the issue is in the README.md file, please correct the issue yourself in your pull request.
- If the issue is in the repository wiki, please use the space below to describe the errors for a contributor to fix.

*Please use this space to describe any errors in the documentation.*

---

**Thank you for contributing to Melody :heart:**
