### PR TITLE
Fix bug with channel empty disconnect message

### DIFF
--- a/src/events/player/channelEmpty.js
+++ b/src/events/player/channelEmpty.js
@@ -20,8 +20,8 @@ module.exports = {
 };
 
 function formatMS(ms) {
-    var s = Math.floor(ms / 1000);
-    var m = Math.floor(ms / (1000 * 60));
+    var s = Math.floor(ms / 1000) % 60;
+    var m = Math.floor(ms / (1000 * 60)) % 60;
     var h = Math.floor(ms / (1000 * 60 * 60));
 
     var str = "";


### PR DESCRIPTION
### Checklist
- [X] The pull request has a descriptive title.
- [X] All code changed has been thoroughly tested.
- [X] All code changed has been formatted with prettier using `npm run format`.

---

### Description
- Fixes bug that caused the message sent when the bot disconnected due to the channel being empty showing the same time in minutes and seconds, which led to the final time that was shown in the embed being incorrect.

---

### Documentation
- [X] None of the [documentation](https://github.com/NerdyTechy/Melody/wiki) or information in the [README](https://github.com/NerdyTechy/Melody/blob/master/README.md) is incorrect following these changes.

**If any documentation is incorrect as a result of these changes:**
- If the issue is in the README.md file, please correct the issue yourself in your pull request.
- If the issue is in the repository wiki, please use the space below to describe the errors for a contributor to fix.

*Please use this space to describe any errors in the documentation.*

---

**Thank you for contributing to Melody :heart:**
